### PR TITLE
Single-source the version for setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 from setuptools import setup
-
-from peewee_mssql import __version__
+import io
+import os
+import os.path
+import re
 
 def long_description():
     descr = open('README.rst', 'r').read()
@@ -12,9 +14,27 @@ def long_description():
 
     return descr
 
+
+def read(*names, **kwargs):
+    with io.open(
+        os.path.join(os.path.dirname(__file__), *names),
+        encoding=kwargs.get("encoding", "utf8")
+    ) as fp:
+        return fp.read()
+
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+
 setup(
     name='peewee-mssql',
-    version=__version__,
+    version=find_version("peewee_mssql.py"),
     url='https://github.com/cour4g3/peewee-mssql',
     license='MIT',
     author='Michael de Villiers',


### PR DESCRIPTION
Following the first option at
https://packaging.python.org/single_source_version/